### PR TITLE
feat(quanta): add an example of Magento extra headers for Quanta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # examples
+
 A community-driven repository showcasing examples using Front-Commerce features
+
+## Usage
+
+This module is aimed at being used in a [Front-Commerce](https://developers.front-commerce.com/) project.
+
+1. clone the [Front-Commerce skeleton](https://gitlab.blackswift.cloud/front-commerce/front-commerce-skeleton), or use an existing Front-Commerce project
+2. add this module as a submodule: `git submodule add git@github.com:front-commerce/examples.git examples`
+
+Then, follow instructions from the `README.md` files available in each example directory.

--- a/analytics/matomo/README.md
+++ b/analytics/matomo/README.md
@@ -1,13 +1,12 @@
-# Matomo example plugin 
+# Matomo example plugin
 
 Example Matomo analytics plugin.
 
 ## Usage
 
-1. clone the [Front-Commerce skeleton](https://gitlab.com/front-commerce/front-commerce-skeleton), or use an existing Front-Commerce project
-2. add this module as a submodule: `git submodule add git@github.com:front-commerce/examples.git examples`
-3. install `@jonkoops/matomo-tracker` package: `npm install @jonkoops/matomo-tracker`
-4. update your `src/config/analytics.js` file as follows:
+1. add the `examples` module to your project (see [../../README.md](../../README.md))
+1. install `@jonkoops/matomo-tracker` package: `npm install @jonkoops/matomo-tracker`
+1. update your `src/config/analytics.js` file as follows:
 
 ```diff
 diff --git a/src/config/analytics.js b/src/config/analytics.js

--- a/analytics/meta-pixel/README.md
+++ b/analytics/meta-pixel/README.md
@@ -1,13 +1,12 @@
-# Meta Pixel example plugin 
+# Meta Pixel example plugin
 
 Example Meta Pixel analytics plugin.
 
 ## Usage
 
-1. clone the [Front-Commerce skeleton](https://gitlab.com/front-commerce/front-commerce-skeleton), or use an existing Front-Commerce project
-2. add this module as a submodule: `git submodule add git@github.com:front-commerce/examples.git examples`
-3. install `react-facebook-pixel` package: `npm install react-facebook-pixel`
-4. update your `src/config/analytics.js` file as follows:
+1. add the `examples` module to your project (see [../../README.md](../../README.md))
+1. install `react-facebook-pixel` package: `npm install react-facebook-pixel`
+1. update your `src/config/analytics.js` file as follows:
 
 ```diff
 diff --git a/src/config/analytics.js b/src/config/analytics.js

--- a/quanta/README.md
+++ b/quanta/README.md
@@ -1,0 +1,46 @@
+# Quanta integration in Front-Commerce
+
+This example module illustrates how to forward HTTP headers from [Quanta](https://www.quanta.io/) attackers to Magento.
+
+## Why?
+
+When load testing an application using Quanta, attackers attach a `x-quanta` HTTP header to each request. This header is then used in Magento servers as a correlation id, to provide detailed metrics on the impact the load has on Magento.
+
+## What?
+
+It adds a [Configuration Provider](https://developers.front-commerce.com/docs/2.x/advanced/server/configurations#what-is-a-configuration-provider) to the application.
+
+This provider customizes the `magento.api.extraHeaders` configuration to include the `x-quanta` headers from the current request. This configuration works for both [Magento 1](https://developers.front-commerce.com/docs/2.x/magento1/advanced#additional-headers-in-magento-api-calls) and [Magento 2](https://developers.front-commerce.com/docs/2.x/magento2/advanced#additional-headers-in-magento-api-calls).
+
+## Usage
+
+1. add the `examples` module to your project (see [../README.md](../README.md))
+1. register the `examples/quanta` module in your project (using the `.front-commerce.js::modules` key):
+```diff
+--- a/.front-commerce.js
++++ b/.front-commerce.js
+@@ -2,16 +2,12 @@ module.exports = {
+   name: "Front-Commerce Skeleton",
+   url: "http://localhost:4000",
+   modules: [
++    "./examples/quanta",
+     "./node_modules/front-commerce/theme-chocolatine",
+     "./src",
+   ],
+   serverModules: [
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
+```
+
+## Test
+
+You can simulate an HTTP request from Quanta attackers with the following `curl` command:
+```
+curl -I http://localhost:4000/ -H "x-quanta: 2801 1680261120 magento"
+```
+
+## Additional information
+
+Here's the specification of the `x-quanta` header:
+
+- format: `x-quanta: [0-9]+ [0-9]+ magento`
+- example: `x-quanta: 2801 1680261120 magento`

--- a/quanta/server/module.config.js
+++ b/quanta/server/module.config.js
@@ -1,0 +1,35 @@
+import mem from "mem";
+import configService from "server/core/config/configService";
+
+const memoizedMagentoExtraHeaders = mem(
+  (quantaHeader) => {
+    if (!quantaHeader) {
+      return {};
+    }
+    return {
+      magento: {
+        api: {
+          extraHeaders: {
+            "x-quanta": quantaHeader,
+          },
+        },
+      },
+    };
+  },
+  { maxAge: 5000 } // prevent memory leaks in case lots of different values pile up
+);
+
+const quantaConfigProvider = {
+  name: "quanta",
+  /**
+   * @param {import("express").Request} req
+   */
+  slowValuesOnEachRequest: (req) => {
+    const quantaHeader = req.header("x-quanta");
+    return memoizedMagentoExtraHeaders(quantaHeader);
+  },
+};
+
+configService.append(quantaConfigProvider);
+
+export default {};


### PR DESCRIPTION
This PR adds a working example of a Quanta module that forwards the `x-quanta`  header used by Quanta attackers to Magento remote services.

It also _refactors_ the usage instructions to have a shared instruction on how to use this repository.