### PR TITLE
doc(quanta): replace usage of "attackers" with "browsers"

### DIFF
--- a/quanta/README.md
+++ b/quanta/README.md
@@ -1,10 +1,10 @@
 # Quanta integration in Front-Commerce
 
-This example module illustrates how to forward HTTP headers from [Quanta](https://www.quanta.io/) attackers to Magento.
+This example module illustrates how to forward HTTP headers from [Quanta](https://www.quanta.io/) browsers to Magento.
 
 ## Why?
 
-When load testing an application using Quanta, attackers attach a `x-quanta` HTTP header to each request. This header is then used in Magento servers as a correlation id, to provide detailed metrics on the impact the load has on Magento.
+When load testing an application using Quanta, browsers attach a `x-quanta` HTTP header to each request. This header is then used in Magento servers as a correlation id, to provide detailed metrics on the impact the load has on Magento.
 
 ## What?
 
@@ -33,7 +33,7 @@ This provider customizes the `magento.api.extraHeaders` configuration to include
 
 ## Test
 
-You can simulate an HTTP request from Quanta attackers with the following `curl` command:
+You can simulate an HTTP request from Quanta browsers with the following `curl` command:
 ```
 curl -I http://localhost:4000/ -H "x-quanta: 2801 1680261120 magento"
 ```


### PR DESCRIPTION
that is the correct term and more correct, since it can also be used in other contexts than load monitoring

This is based on a feedback from the Quanta team:
> Juste une remarque, tu peux plutot parler de "Quanta browsers" que "Quanta attackers" dans ta doc, car ce forward sert avant-tout à ce que les sondes monitoring Quanta (donc les browsers Quanta) puissent profiler le code, indépendamment du fait que ca soit dans le cadre d'un test de montée en charge ou non. D'ailleurs les sondes du TMCs lui-même n'indiquent pas ce header, pour ne pas profiler tout le trafic.

_I'll merge it right away, since there isn't much to review!_