### PR TITLE
feat(config-providers): add initial example of configuration providers

### DIFF
--- a/configProviders/README.md
+++ b/configProviders/README.md
@@ -1,0 +1,64 @@
+# Configuration providers
+
+This example shows different practical use of [Configuration Providers](https://developers.front-commerce.com/docs/2.x/advanced/server/configurations#what-is-a-configuration-provider) in Front-Commerce.
+
+## Why?
+
+You might want to customize a configuration in Front-Commerce based on different criteria.
+
+## Usage
+
+1. add the `examples` module to your project (see [../README.md](../README.md))
+1. register the `examples/configProviders` GraphQL module in your project (using the `.front-commerce.js::modules` and `.front-commerce.js::serverModules` keys):
+```diff
+--- a/.front-commerce.js
++++ b/.front-commerce.js
+@@ -2,16 +2,12 @@ module.exports = {
+   name: "Front-Commerce Skeleton",
+   url: "http://localhost:4000",
+   modules: [
++    "./examples/configProviders",
+     "./node_modules/front-commerce/theme-chocolatine",
+     "./src",
+   ],
+   serverModules: [
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
++    {
++      name: "ConfigProviders",
++      path: "./examples/configProviders/server/graphql-module",
++    },
+```
+1. add a `FRONT_COMMERCE_EXAMPLE_MANDATORY_STATIC_VALUE=my-value` environment variable to `.env` to prevent a *"Error: example.mandatoryStaticValue: must be of type String"* from the configuration system due to a missing mandatory configuration.
+
+## Test
+
+Add the `DEBUG=example:config-providers` flag to your `.env` to view debug logs that could be useful to understand what happens.
+
+Then start the application, and run queries. You will see the configuration in the console.
+
+You can update your `store.js` by duplicating your existing shop configuration and create a new one with a different URL. You'll see that dynamic values will change depending on the request.
+
+Example:
+
+```diff
+// ./src/config/stores.js
+module.exports = {
+  default: {
+    url: process.env.FRONT_COMMERCE_URL,
+    locale: "en-US",
+    currency: "EUR",
+    default_country_id: "GB",
+    countries: (IsoCountries) =>
+      IsoCountries.registerLocale(require("i18n-iso-countries/langs/en.json")),
+  },
++  v2: {
++    url: process.env.FRONT_COMMERCE_URL + "/v2",
++    locale: "en-US",
++    currency: "EUR",
++    default_country_id: "GB",
++    magentoStoreCode: "default",
++    countries: (IsoCountries) =>
++      IsoCountries.registerLocale(require("i18n-iso-countries/langs/en.json")),
++  },
+};
+```

--- a/configProviders/server/graphql-module/config/exampleConfigProvider.js
+++ b/configProviders/server/graphql-module/config/exampleConfigProvider.js
@@ -1,0 +1,91 @@
+import { getCurrentShopConfig } from "server/core/config/getShopConfig";
+import mem from "mem";
+import d from "debug";
+
+const debug = d("example:config-providers");
+
+/**
+ * In order to prevent expensive calculations that would
+ * be executed on each request, FC will warn if it detects that
+ * 2 consecutive calls with the same value returns different objects.
+ *
+ * For this reason, it's a good practice to memoize the configuration
+ * based on a single criteria (here the shop id).
+ *
+ * /!\ Warning: you must ensure that the cache key has a known cardinality.
+ *     if the cache key is dynamic, it could cause memory leaks.
+ */
+const memoizedConfigurationPerShop = mem(
+  (shopConfig) => {
+    // should only be executed once per store and per node process
+    debug("Current shop config (from stores.js)", shopConfig);
+
+    return {
+      example: {
+        runtimeValuePerShop: `Uppercased URL: ${shopConfig.url.toUpperCase()}`,
+      },
+    };
+  },
+  {
+    // We use the shop id as the cache key. This isn't needed if the 1st parameter is a scalar.
+    // See mem's documentation for details https://www.npmjs.com/package/mem
+    cacheKey: (args) => {
+      const shopConfig = args[0];
+      return shopConfig.id;
+    },
+  }
+);
+
+/**
+ * @typedef {object} ExampleConfig Example configuration
+ *
+ * @property {string} mandatoryStaticValue
+ * @property {string} staticValueWithDefault
+ * @property {string} runtimeValuePerShop
+ */
+const exampleConfigProvider = {
+  name: "example",
+  /**
+   * Returns a schema object containing the example configuration properties.
+   * This is what defines the constraints you want for your configuration.
+   */
+  schema: () => ({
+    example: {
+      mandatoryStaticValue: {
+        doc: "A mandatory value which doesn't change in the runtime",
+        format: String,
+        env: "FRONT_COMMERCE_EXAMPLE_MANDATORY_STATIC_VALUE",
+        default: null, // null isn't a String, so if no value is provided it will fail
+      },
+      staticValueWithDefault: {
+        doc: "A configuration that has a default value if no env var is defined",
+        format: String,
+        env: "FRONT_COMMERCE_EXAMPLE_STATIC_VALUE_WITH_DEFAULT",
+        default: "default value",
+      },
+      runtimeValuePerShop: {
+        doc: "A configuration whose value is determined at runtime based on the current shop",
+        format: String,
+        default: "",
+      },
+    },
+  }),
+
+  /**
+   * slowValuesOnEachRequest allows you to derive a value from each request.
+   * It can access already resolved configurations from previous providers.
+   *
+   * In this example, we derive a value from the current shop scope. That's why
+   * the provider is inserted after the shop config provider (in `../index.js`).
+   *
+   * @see https://developers.front-commerce.com/docs/2.x/advanced/server/configurations#values-depending-on-the-request-key-slowvaluesoneachrequest-optional
+   * @param {import("express").Request} req The raw HTTP request
+   * @param {Object} config The configuration containing static values and dynamic values from previous providers (here shop)
+   */
+  slowValuesOnEachRequest: (_req, config) => {
+    const currentShopConfig = getCurrentShopConfig(config);
+    return memoizedConfigurationPerShop(currentShopConfig);
+  },
+};
+
+export default exampleConfigProvider;

--- a/configProviders/server/graphql-module/index.js
+++ b/configProviders/server/graphql-module/index.js
@@ -1,0 +1,27 @@
+import configService from "server/core/config/configService";
+import exampleConfigProvider from "./config/exampleConfigProvider";
+import d from "debug";
+
+const debug = d("example:config-providers");
+
+debug(
+  "GraphQL module: registering the example config provider in the application (after the shop config provider because we need the current shop)"
+);
+configService.insertAfter("shop", exampleConfigProvider);
+// without a required dependency on shop, you could `.append()` the config provider like this:
+// configService.append(exampleConfigProvider);
+
+export default {
+  namespace: "Example/ConfigProviders",
+  contextEnhancer: ({ req }) => {
+    /**
+     * @type {import("./config/exampleConfigProvider").ExampleConfig}
+     */
+    const exampleConfig = req.config.example;
+    debug("req.config.example", exampleConfig);
+
+    // use with typing from JSDoc!
+    // exampleConfig.mandatoryStaticValue
+    return {};
+  },
+};


### PR DESCRIPTION
This MR adds a new example aimed at explaining how to register a configuration provider.

The configuration provider is registered from a GraphQL module to illustrate how to access it (with JSDoc typing) from a `contextEnhancer`.

The provider has 3 type of values:
- mandatory static value
- optional static value (with default)
- dynamic value per request, to illustrate common practices of `slowValuesOnEachRequest`