### PR TITLE
Alternative checkout example

### DIFF
--- a/alternative-checkout/README.md
+++ b/alternative-checkout/README.md
@@ -1,0 +1,45 @@
+# Alternative checkout
+
+This example shows a way to alter the checkout flow by "merging" the address and shipping method steps from the checkout, while reusing most of Front-Commerce components.
+
+## Why ?
+
+You might want to customize the checkout flow, and due to its core behavior, it might not be straighforward.
+
+## What ?
+
+This example module only adds and modifies front end components. It adds a new component `AddressAndShipingMethod`, which replaces both the first and the second step of the original `stepDefinitions.js`.
+
+In order to do so, the first step now uses both the validation checks from the Address and the Shipping method steps. `Address` and `ChooseShippingMethod` components have been modified to fit the new wanted behavior, and mutation definitions have been moved to `AddressAndShippingMethod` parent component in order to keep the loading and disabling mechanism at the same place.
+
+## Usage
+
+1. add the `examples` module to your project (see [../README.md](../README.md))
+1. register the `examples/alternative-checkout` module in your project (using the `.front-commerce.js::modules` key):
+```diff
+--- a/.front-commerce.js
++++ b/.front-commerce.js
+@@ -2,16 +2,12 @@ module.exports = {
+   name: "Front-Commerce Skeleton",
+   url: "http://localhost:4000",
+   modules: [
+     "./node_modules/front-commerce/theme-chocolatine",
+     "./src",
++    "./examples/alternative-checkout",
+   ],
+   serverModules: [
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
+```
+```diff
+--- a/.front-commerce.js
++++ b/.front-commerce.js
+@@ -18,5 +19,6 @@ module.exports = {
+     { name: "FrontCommerce", path: "front-commerce/src/web" },
+     { name: "ThemeChocolatine", path: "front-commerce/theme-chocolatine/web" },
+     { name: "Skeleton", path: "./src/web" },
++    { name: "AlternativeCheckout", path: "./examples/alternative-checkout/web" },
+   ],
+};
+```
+
+By doing this, the checkout flow of your application should now contain one less step !

--- a/alternative-checkout/translations/en.json
+++ b/alternative-checkout/translations/en.json
@@ -1,0 +1,4 @@
+{
+  "modules.Checkout.ShippingMethod.ChooseShippingMethod.noShippingAddress": "Please select a shipping address before choosing a shipping method.",
+  "pages.Checkout.addressAndShippingProgressLabel": "Address and shipping"
+}

--- a/alternative-checkout/translations/fr.json
+++ b/alternative-checkout/translations/fr.json
@@ -1,0 +1,4 @@
+{
+  "modules.Checkout.ShippingMethod.ChooseShippingMethod.noShippingAddress": "Veuillez sélectionner une adresse de livraison pour choisir votre méthode de livraison.",
+  "pages.Checkout.addressAndShippingProgressLabel": "Adresse et livraison"
+}

--- a/alternative-checkout/web/theme/modules/Checkout/Address/Address.js
+++ b/alternative-checkout/web/theme/modules/Checkout/Address/Address.js
@@ -1,0 +1,77 @@
+import React from "react";
+import { injectIntl, defineMessages } from "react-intl";
+import AddressQuery from "./AddressQuery.gql";
+import EnhanceAddress, { FORM_TYPE_EXISTING_ADDRESS } from "./EnhanceAddress";
+import TitledCard from "theme/components/molecules/Card/TitledCard";
+import { BodyParagraph } from "theme/components/atoms/Typography/Body";
+import ExistingAddress from "./ExistingAddress";
+import NewAddress from "./NewAddress";
+import { ErrorAlert } from "theme/components/molecules/Alert";
+import { ACCOUNT_TYPE } from "theme/pages/Checkout/ChooseAccount/ChooseAccount";
+
+const messages = defineMessages({
+  yourAddress: {
+    id: "modules.Checkout.Address.billingAddress",
+    defaultMessage: "Your billing address",
+  },
+  selectAnAddress: {
+    id: "modules.Checkout.Address.selectAnAddress",
+    defaultMessage:
+      "Please fill your address in order to proceed with your checkout",
+  },
+});
+
+const Address = ({
+  defaultBilling,
+  defaultShipping,
+  addresses,
+  onChooseAddress,
+  isEditingBillingAddress,
+  isEditingShippingAddress,
+  formType,
+  shouldAskShipping = true,
+  intl,
+  commandPending,
+  hasMessage,
+  message,
+  checkoutType,
+  onAddressChange,
+}) => {
+  return (
+    <TitledCard
+      title={intl.formatMessage(messages.yourAddress)}
+      description={
+        <BodyParagraph>
+          {intl.formatMessage(messages.selectAnAddress)}
+        </BodyParagraph>
+      }
+    >
+      {!commandPending && hasMessage && <ErrorAlert>{message}</ErrorAlert>}
+      {formType === FORM_TYPE_EXISTING_ADDRESS ? (
+        <ExistingAddress
+          onAddressChange={onAddressChange}
+          addresses={addresses}
+          pending={commandPending}
+          defaultShipping={defaultShipping && defaultShipping.id}
+          defaultBilling={defaultBilling && defaultBilling.id}
+          onChooseAddress={onChooseAddress}
+          isEditingBillingAddress={isEditingBillingAddress}
+          isEditingShippingAddress={isEditingShippingAddress}
+          shouldAskShipping={shouldAskShipping}
+        />
+      ) : (
+        <NewAddress
+          onChooseAddress={onChooseAddress}
+          shouldAskShipping={shouldAskShipping}
+          pending={commandPending}
+          shouldSaveAddress={checkoutType !== ACCOUNT_TYPE.GUEST}
+          withEmail={checkoutType === ACCOUNT_TYPE.GUEST}
+        />
+      )}
+    </TitledCard>
+  );
+};
+
+export default EnhanceAddress({
+  AddressQuery: AddressQuery,
+})(injectIntl(Address));

--- a/alternative-checkout/web/theme/modules/Checkout/Address/EnhanceAddress.js
+++ b/alternative-checkout/web/theme/modules/Checkout/Address/EnhanceAddress.js
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import { compose, branch, withHandlers, withProps } from "recompose";
+import { graphql } from "react-apollo";
+import { ACCOUNT_TYPE } from "theme/pages/Checkout/ChooseAccount/ChooseAccount";
+import AddressLoading from "./AddressLoading";
+
+export const FORM_TYPE_EXISTING_ADDRESS = "existing";
+export const FORM_TYPE_NEW_ADDRESS = "new";
+
+export default ({ AddressQuery }) =>
+  compose(
+    branch(
+      (props) => props.checkoutType === ACCOUNT_TYPE.GUEST,
+      withProps({
+        loading: false,
+        defaultBilling: null,
+        defaultShipping: null,
+        addresses: [],
+      }),
+      graphql(AddressQuery, {
+        props: ({ data, ownProps }) => ({
+          loading: data.loading,
+          defaultBilling:
+            ownProps.initialAddress?.billing ||
+            (!data.loading && data.me.default_billing),
+          defaultShipping:
+            ownProps.initialAddress?.shipping ||
+            (!data.loading && data.me.default_shipping),
+          addresses: !data.loading && data.me.addresses,
+        }),
+      })
+    ),
+    branch(
+      (props) => props.loading,
+      () => AddressLoading,
+      (BaseComponent) => BaseComponent
+    ),
+    (BaseComponent) => {
+      // Once we're displaying a specific form type to the user
+      // we won't change afterward to avoid any unexpected behavior
+      // if some data changes
+      const ComponentWithAddressFormType = (props) => {
+        const [formType, setFormType] = useState(null);
+
+        const { loading, addresses } = props;
+        useEffect(() => {
+          if (!formType && !loading && addresses) {
+            if (addresses.length === 0) {
+              setFormType(FORM_TYPE_NEW_ADDRESS);
+            } else {
+              setFormType(FORM_TYPE_EXISTING_ADDRESS);
+            }
+          }
+        }, [formType, loading, addresses]);
+
+        return <BaseComponent {...props} formType={formType} />;
+      };
+      return ComponentWithAddressFormType;
+    },
+    withHandlers({
+      onChooseAddress: (props) => (billing, shipping, email) => {
+        if (
+          !billing ||
+          (props.initialAddress &&
+            props.initialAddress.billing &&
+            props.initialAddress.billing.id &&
+            props.initialAddress.billing.id === billing.id)
+        ) {
+          props.onChooseAddress(billing, shipping);
+        } else {
+          props.setBillingAddress({
+            address: billing,
+            email: email,
+            onSuccess: () => {
+              props.onChooseAddress(billing, shipping, email);
+            },
+          });
+        }
+      },
+    })
+  );

--- a/alternative-checkout/web/theme/modules/Checkout/Address/ExistingAddress/ExistingAddress.js
+++ b/alternative-checkout/web/theme/modules/Checkout/Address/ExistingAddress/ExistingAddress.js
@@ -1,0 +1,155 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { defineMessages, injectIntl } from "react-intl";
+import EnhanceExistingAddress from "./EnhanceExistingAddress";
+import AddressSelector from "./AddressSelector";
+import { PrimaryButton } from "theme/components/atoms/Button";
+import { ErrorAlert } from "theme/components/molecules/Alert";
+import FormTitle from "theme/components/molecules/Form/FormTitle";
+import FormActions from "theme/components/molecules/Form/FormActions";
+import Checkbox from "theme/components/atoms/Form/Input/Checkbox";
+import { H1 } from "theme/components/atoms/Typography/Heading";
+import { BodyStrong } from "theme/components/atoms/Typography/Body";
+import Fieldset from "theme/components/atoms/Form/Fieldset";
+import Stack from "theme/components/atoms/Layout/Stack";
+import StepActions from "theme/components/templates/MultiStep/StepActions";
+
+const messages = defineMessages({
+  useForShippingLabel: {
+    id: "modules.Checkout.Address.ExistingAddress.useForShipping",
+    defaultMessage: "Ship to this address",
+  },
+  submitLabel: {
+    id: "modules.Checkout.Address.ExistingAddress.submit",
+    defaultMessage: "Continue my order",
+  },
+  selectAShipping: {
+    id: "modules.Checkout.Address.ExistingAddress.selectAShipping",
+    defaultMessage: "Please select a shipping address",
+  },
+  shippingAddress: {
+    id: "modules.Checkout.Address.ExistingAddress.shippingAddress",
+    defaultMessage: "Your shipping address",
+  },
+});
+
+const ExistingAddress = (props) => {
+  const [billing, setBilling] = useState(null);
+  const [shipping, setShipping] = useState(null);
+  const [useBillingForShipping, setUseBillingForShipping] = useState(
+    props.defaultShipping === props.defaultBilling || !props.defaultShipping
+  );
+  const [error, setError] = useState(null);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    props.handleSubmit({
+      billing: billing,
+      shipping: shipping,
+    });
+  };
+
+  const onToggleShipping = () => {
+    setUseBillingForShipping(!useBillingForShipping);
+    setShipping(useBillingForShipping ? null : billing);
+    setError(useBillingForShipping ? error : null);
+  };
+
+  const onChange = (type, data) => {
+    if (useBillingForShipping) {
+      setBilling(data);
+      setShipping(data);
+      setError(null);
+    } else if (type === "billing") {
+      setBilling(data);
+    } else if (type === "shipping") {
+      setShipping(data);
+    } else {
+      setError(error);
+    }
+    props.onAddressChange();
+  };
+
+  const displayInvalidShippingError = () => {
+    setError(props.intl.formatMessage(messages.selectAShipping));
+  };
+
+  return (
+    <Stack desktopSize="2" mobileSize="4">
+      <AddressSelector
+        key="billing"
+        name="billing"
+        isEditingInitially={props.isEditingBillingAddress}
+        addresses={props.addresses}
+        value={billing}
+        onChange={(data) => onChange("billing", data)}
+      />
+
+      {props.shouldAskShipping && (
+        <Stack key="shipping" desktopSize="2" mobileSize="4">
+          <Fieldset key="useForShipping">
+            <Checkbox
+              id="use_for_shipping"
+              name="use_for_shipping"
+              onChange={onToggleShipping}
+              checked={useBillingForShipping}
+              label={
+                <BodyStrong>
+                  {props.intl.formatMessage(messages.useForShippingLabel)}
+                </BodyStrong>
+              }
+              appearance="center"
+            />
+          </Fieldset>
+
+          {!useBillingForShipping && (
+            <Stack key="shippingSelector" mobileSize="4" desktopSize="2">
+              <FormTitle>
+                <H1 as="h2">
+                  {props.intl.formatMessage(messages.shippingAddress)}
+                </H1>
+              </FormTitle>
+              <AddressSelector
+                name="shipping"
+                isEditingInitially={props.isEditingShippingAddress}
+                addresses={props.addresses}
+                value={shipping}
+                onChange={(data) => onChange("shipping", data)}
+              />
+            </Stack>
+          )}
+        </Stack>
+      )}
+
+      {error && <ErrorAlert key="error">{error}</ErrorAlert>}
+
+      <StepActions key="actions">
+        <FormActions>
+          <PrimaryButton
+            state={
+              props.pending
+                ? "pending"
+                : props.shouldAskShipping && !useBillingForShipping && !shipping
+                ? "disabled"
+                : undefined
+            }
+            onClick={handleSubmit}
+            onDisableClick={displayInvalidShippingError}
+          >
+            {props.intl.formatMessage(messages.submitLabel)}
+          </PrimaryButton>
+        </FormActions>
+      </StepActions>
+    </Stack>
+  );
+};
+
+ExistingAddress.propTypes = {
+  addresses: PropTypes.array.isRequired,
+};
+
+ExistingAddress.defaultProps = {
+  shouldAskShipping: true,
+};
+
+export default EnhanceExistingAddress(injectIntl(ExistingAddress));

--- a/alternative-checkout/web/theme/modules/Checkout/AddressAndShippingMethod/AddressAndShippingMethod.js
+++ b/alternative-checkout/web/theme/modules/Checkout/AddressAndShippingMethod/AddressAndShippingMethod.js
@@ -1,0 +1,63 @@
+import React from "react";
+import { compose } from "recompose";
+import Address from "theme/modules/Checkout/Address";
+import Stack from "theme/components/atoms/Layout/Stack";
+import ChooseShippingMethod from "theme/modules/Checkout/ShippingMethod";
+import EnhanceAddressAndShippingMethod from "./EnhanceAddressAndShippingMethod";
+import SetBillingAddressMutation from "theme/modules/Checkout/Address/SetBillingAddressMutation.gql";
+import SetShippingInformationMutation from "theme/modules/Checkout/ShippingMethod/SetShippingInformationMutation.gql";
+import CartIdQuery from "theme/modules/Checkout/withCartId/CartIdQuery.gql";
+import withCartId from "theme/modules/Checkout/withCartId";
+
+const AddressAndShippingMethod = (props) => {
+  // Invalidate shipping method selection
+  // in case the customer changed its address
+  const onAddressChange = () => {
+    props.onChooseAddress(null, null);
+  };
+
+  return (
+    <Stack desktopSize="2" mobileSize="4">
+      <Address
+        onAddressChange={onAddressChange}
+        checkoutType={props.checkoutType}
+        isEditingBillingAddress={props.isEditingBillingAddress}
+        isEditingShippingAddress={props.isEditingShippingAddress}
+        initialAddress={{
+          billing: props.billingAddress,
+          shipping: props.shippingAddress,
+        }}
+        onChooseAddress={props.onChooseAddress}
+        shouldAskShipping={props.isShippable ?? true}
+        setBillingAddress={props.setBillingAddress}
+        commandPending={props.commandPending}
+        hasMessage={props.hasMessage}
+        message={props.message}
+      />
+      <ChooseShippingMethod
+        shippingAddress={props.shippingAddress}
+        billingAddress={props.billingAddress}
+        setShippingAddress={props.setShippingAddress}
+        setBillingAddress={props.setBillingAddress}
+        initialShipping={{
+          shippingMethod: props.shippingMethod,
+          shippingAdditionalInfo: props.shippingAdditionalInfo,
+        }}
+        onChooseShippingMethod={props.onChooseShippingMethod}
+        onChangeShippingAddress={() => props.gotoStepNumber(0)}
+        commandPending={props.commandPending}
+        hasMessage={props.hasMessage}
+        message={props.message}
+        cartId={props.cartId}
+      />
+    </Stack>
+  );
+};
+
+export default compose(
+  withCartId({ CartIdQuery }),
+  EnhanceAddressAndShippingMethod({
+    SetBillingAddressMutation,
+    SetShippingInformationMutation,
+  })
+)(AddressAndShippingMethod);

--- a/alternative-checkout/web/theme/modules/Checkout/AddressAndShippingMethod/EnhanceAddressAndShippingMethod.js
+++ b/alternative-checkout/web/theme/modules/Checkout/AddressAndShippingMethod/EnhanceAddressAndShippingMethod.js
@@ -1,0 +1,100 @@
+import React from "react";
+import { compose } from "recompose";
+import { FormattedMessage } from "react-intl";
+import makeCommandDispatcher from "web/core/apollo/makeCommandDispatcher";
+import CartQuery from "theme/pages/Cart/CartQuery.gql";
+import { formatCheckoutAddressInput } from "theme/modules/Checkout/Address/formatCheckoutAddress";
+
+export const FORM_TYPE_EXISTING_ADDRESS = "existing";
+export const FORM_TYPE_NEW_ADDRESS = "new";
+
+export default ({
+  SetBillingAddressMutation,
+  SetShippingInformationMutation,
+}) =>
+  compose(
+    makeCommandDispatcher({
+      setBillingAddress:
+        (props) =>
+        ({ address, email, onSuccess }) => {
+          return {
+            options: {
+              mutation: SetBillingAddressMutation,
+              variables: {
+                email,
+                billingAddress: formatCheckoutAddressInput(address),
+              },
+              update: (store, { data }) => {
+                const response = data.setCheckoutBillingAddress;
+                if (response.success) {
+                  const cart = response.cart;
+
+                  store.writeQuery({
+                    query: CartQuery,
+                    data: { cart: cart },
+                  });
+                }
+              },
+            },
+            callback: (result) => {
+              if (result.status === "success") {
+                onSuccess();
+              }
+            },
+            messages: {
+              error: (
+                <FormattedMessage
+                  id="modules.Checkout.Address.error"
+                  defaultMessage="An error occured while recording your billing address. Please try again and if the problem persists contact us."
+                />
+              ),
+            },
+          };
+        },
+      onChooseShippingMethod: (props) => (method) => {
+        const { method_code, carrier_code, additionalData } = method;
+        return {
+          options: {
+            mutation: SetShippingInformationMutation,
+            variables: {
+              cartId: props.cartId,
+              shippingAddress: formatCheckoutAddressInput(
+                props.shippingAddress
+                  ? props.shippingAddress
+                  : { id: props.shippingAddressId }
+              ),
+              shippingMethod: {
+                method_code,
+                carrier_code,
+                additionalData,
+              },
+            },
+            update: (store, { data }) => {
+              const response = data.setCheckoutShippingInformation;
+              if (response.success) {
+                const cart = response.cart;
+
+                store.writeQuery({
+                  query: CartQuery,
+                  data: { cart: cart },
+                });
+              }
+            },
+          },
+          callback: (result) => {
+            if (result.status === "success") {
+              props.onChooseShippingMethod(method);
+            }
+          },
+          messages: {
+            error: (
+              <FormattedMessage
+                id="modules.Checkout.ShippingMethod.ChooseShippingMethod.error"
+                defaultMessage="An error occured while recording your shipping information. Please try again and if the problem persists contact us."
+              />
+            ),
+          },
+        };
+      },
+    })
+  );

--- a/alternative-checkout/web/theme/modules/Checkout/AddressAndShippingMethod/index.js
+++ b/alternative-checkout/web/theme/modules/Checkout/AddressAndShippingMethod/index.js
@@ -1,0 +1,3 @@
+import AddressAndShippingMethod from "./AddressAndShippingMethod";
+
+export default AddressAndShippingMethod;

--- a/alternative-checkout/web/theme/modules/Checkout/ShippingMethod/ChooseShippingMethod.js
+++ b/alternative-checkout/web/theme/modules/Checkout/ShippingMethod/ChooseShippingMethod.js
@@ -1,0 +1,161 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { compose, branch } from "recompose";
+import { defineMessages, injectIntl, FormattedMessage } from "react-intl";
+import TitledCard from "theme/components/molecules/Card/TitledCard";
+import ShippingMethodForm from "./ShippingMethodForm";
+import EnhanceChooseShippingMethod from "./EnhanceChooseShippingMethod";
+import { BodyParagraph } from "theme/components/atoms/Typography/Body";
+import LoadingArea from "theme/components/molecules/LoadingArea";
+import { ErrorAlert, InfoAlert } from "theme/components/molecules/Alert";
+import Button from "theme/components/atoms/Button";
+import Link from "theme/components/atoms/Typography/Link";
+import AvailableShippingMethodQuery from "./AvailableShippingMethodQuery.gql";
+import addressShape from "theme/pages/Account/AddressBook/addressShape";
+
+const messages = defineMessages({
+  yourShippingOptions: {
+    id: "modules.Checkout.ShippingMethod.ChooseShippingMethod.yourShippingOptions",
+    defaultMessage: "Shipping methods",
+  },
+  chooseShippingOption: {
+    id: "modules.Checkout.ShippingMethod.ChooseShippingMethod.chooseShippingOption",
+    defaultMessage: "Choose the option that fits the most your need",
+  },
+  onlyOneShippingOption: {
+    id: "modules.Checkout.ShippingMethod.ChooseShippingMethod.onlyOneShippingOption",
+    defaultMessage: "Your order will be shipped using this method",
+  },
+});
+
+const Description = injectIntl(({ intl, numberOfOptions }) => (
+  <BodyParagraph>
+    {intl.formatMessage(
+      numberOfOptions > 1
+        ? messages.chooseShippingOption
+        : messages.onlyOneShippingOption
+    )}
+  </BodyParagraph>
+));
+
+const NoShippingAddress = ({ intl }) => {
+  return (
+    <TitledCard title={intl.formatMessage(messages.yourShippingOptions)}>
+      <InfoAlert>
+        <span>
+          <FormattedMessage
+            id="modules.Checkout.ShippingMethod.ChooseShippingMethod.noShippingAddress"
+            defaultMessage="Please select a shipping address before choosing a shipping method."
+          />
+        </span>
+      </InfoAlert>
+    </TitledCard>
+  );
+};
+
+const NoShippingMethod = ({ intl, onChangeShippingAddress }) => {
+  return (
+    <TitledCard title={intl.formatMessage(messages.yourShippingOptions)}>
+      <ErrorAlert>
+        <span>
+          <FormattedMessage
+            id="modules.Checkout.ShippingMethod.ChooseShippingMethod.noMethods"
+            defaultMessage="We cannot ship to the selected address. Please {change_address} or {contact_us} if you need further information."
+            values={{
+              change_address: (
+                <Button appearance="link" onClick={onChangeShippingAddress}>
+                  <FormattedMessage
+                    id="modules.Checkout.ShippingMethod.ChooseShippingMethod.changeAddress"
+                    defaultMessage="change your shipping address"
+                  />
+                </Button>
+              ),
+              contact_us: (
+                <Link to="/contact">
+                  <FormattedMessage
+                    id="modules.Checkout.ShippingMethod.ChooseShippingMethod.contactUs"
+                    defaultMessage="contact us"
+                  />
+                </Link>
+              ),
+            }}
+          />
+        </span>
+      </ErrorAlert>
+    </TitledCard>
+  );
+};
+
+const ChooseShippingMethod = ({
+  intl,
+  onChooseShippingMethod,
+  loading,
+  commandPending,
+  commandResponse,
+  availableShippingMethodList,
+  initialShipping,
+  shippingAddressId,
+  shippingAddress,
+}) => {
+  return (
+    <TitledCard
+      title={intl.formatMessage(messages.yourShippingOptions)}
+      description={
+        loading ? null : (
+          <Description numberOfOptions={availableShippingMethodList.length} />
+        )
+      }
+    >
+      {commandResponse && !commandResponse.success && (
+        <ErrorAlert>
+          <span>{commandResponse.errorMessage}</span>
+        </ErrorAlert>
+      )}
+
+      {loading ? (
+        <LoadingArea>
+          <FormattedMessage
+            id="modules.Checkout.ShippingMethod.ChooseShippingMethod.loading"
+            defaultMessage="Retrieving shipping methods available for your address…"
+          />
+        </LoadingArea>
+      ) : (
+        <ShippingMethodForm
+          onSelect={onChooseShippingMethod}
+          methods={availableShippingMethodList}
+          initialShipping={initialShipping}
+          pending={commandPending}
+          shippingAddress={shippingAddress}
+          shippingAddressId={shippingAddressId}
+        />
+      )}
+    </TitledCard>
+  );
+};
+
+ChooseShippingMethod.propTypes = {
+  shippingAddressId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  shippingAddress: addressShape.isRequired,
+  onChooseShippingMethod: PropTypes.func.isRequired,
+  onChangeShippingAddress: PropTypes.func.isRequired,
+};
+
+export default compose(
+  injectIntl,
+  branch(
+    (props) => !props.loading && !props.shippingAddress,
+    () => NoShippingAddress,
+    (BaseComponent) => BaseComponent
+  ),
+  EnhanceChooseShippingMethod({
+    AvailableShippingMethodQuery,
+  }),
+  branch(
+    (props) =>
+      !props.loading &&
+      (!props.availableShippingMethodList ||
+        props.availableShippingMethodList.length === 0),
+    () => NoShippingMethod,
+    (BaseComponent) => BaseComponent
+  )
+)(ChooseShippingMethod);

--- a/alternative-checkout/web/theme/modules/Checkout/ShippingMethod/EnhanceChooseShippingMethod.js
+++ b/alternative-checkout/web/theme/modules/Checkout/ShippingMethod/EnhanceChooseShippingMethod.js
@@ -1,0 +1,36 @@
+import compose from "recompose/compose";
+import { graphql } from "react-apollo";
+import { formatAddressInput } from "theme/modules/User/Address/AddressForm/formatAddressInput";
+
+const getAddressInput = ({ shippingAddress, shippingAddressId }) => {
+  if (shippingAddress) {
+    return shippingAddress.id
+      ? { id: shippingAddress.id }
+      : formatAddressInput(shippingAddress);
+  } else {
+    return { id: shippingAddressId };
+  }
+};
+
+const EnhanceChooseShippingMethod = ({ AvailableShippingMethodQuery }) =>
+  compose(
+    graphql(AvailableShippingMethodQuery, {
+      options: (props) => {
+        return {
+          fetchPolicy: "network-only",
+          variables: {
+            address: getAddressInput(props),
+          },
+        };
+      },
+      props: ({ data }) => ({
+        loading: data.loading,
+        availableShippingMethodList:
+          !data.loading &&
+          data.checkout &&
+          data.checkout.availableShippingMethodList.data,
+      }),
+    })
+  );
+
+export default EnhanceChooseShippingMethod;

--- a/alternative-checkout/web/theme/pages/Checkout/stepsDefinition.js
+++ b/alternative-checkout/web/theme/pages/Checkout/stepsDefinition.js
@@ -1,0 +1,180 @@
+import React from "react";
+import { defineMessages } from "react-intl";
+import { Redirect } from "react-router";
+
+import ChoosePayment from "theme/modules/Checkout/Payment";
+import PlaceOrder from "theme/modules/Checkout/PlaceOrder";
+import { ACCOUNT_TYPE } from "./ChooseAccount/ChooseAccount";
+import ProgressIcon from "theme/modules/Checkout/ProgressIcon";
+import checkoutFlowOf from "./checkoutFlowOf";
+import AddressAndShippingMethod from "theme/modules/Checkout/AddressAndShippingMethod";
+
+const messages = defineMessages({
+  addressAndShipping: {
+    id: "pages.Checkout.addressAndShippingProgressLabel",
+    defaultMessage: "Address and shipping",
+  },
+  payment: {
+    id: "pages.Checkout.paymentProgressLabel",
+    defaultMessage: "Payment",
+  },
+  validation: {
+    id: "pages.Checkout.paymentValidation",
+    defaultMessage: "Validation",
+  },
+});
+
+const steps = [
+  {
+    renderProgressItem: (state, checkoutState, status) => {
+      return (
+        <ProgressIcon
+          key="address-shipping-method"
+          status={status}
+          icon="user"
+          label={messages.addressAndShipping}
+        />
+      );
+    },
+    renderStep: (props) => {
+      return (
+        <AddressAndShippingMethod
+          checkoutType={props.checkoutState.checkoutType}
+          isEditingBillingAddress={props.checkoutState.isEditingBillingAddress}
+          isEditingShippingAddress={
+            props.checkoutState.isEditingShippingAddress
+          }
+          initialAddress={{
+            billing: props.checkoutState.billingAddress,
+            shipping: props.checkoutState.shippingAddress,
+          }}
+          onChooseAddress={(billing, shipping, email) => {
+            props.checkoutTransaction(() => {
+              props.setEmail(email);
+              props.setBillingAddress(billing);
+              props.setShippingAddress(shipping);
+            });
+          }}
+          shouldAskShipping={props.checkoutState.isShippable ?? true}
+          shippingAddress={props.checkoutState.shippingAddress}
+          billingAddress={props.checkoutState.billingAddress}
+          setShippingAddress={props.setShippingAddress}
+          setBillingAddress={props.setBillingAddress}
+          initialShipping={{
+            shippingMethod: props.checkoutState.shippingMethod,
+            shippingAdditionalInfo: props.checkoutState.shippingAdditionalInfo,
+          }}
+          onChooseShippingMethod={(method) => {
+            const { additionalData, ...rest } = method;
+            props.checkoutTransaction(() => {
+              props.setShippingMethod(rest);
+              props.setShippingAdditionalInfo(additionalData || {});
+            });
+          }}
+          onChangeShippingAddress={() => props.gotoStepNumber(0)}
+        />
+      );
+    },
+    isValid: (checkoutState) => {
+      const isValidAddress = (address) =>
+        checkoutState.checkoutType === ACCOUNT_TYPE.GUEST
+          ? address
+          : address?.id;
+
+      const hasGuestInfo =
+        checkoutState.checkoutType !== ACCOUNT_TYPE.GUEST ||
+        checkoutState.email;
+      return (
+        isValidAddress(checkoutState.billingAddress) &&
+        (!checkoutState.isShippable ||
+          isValidAddress(checkoutState.shippingAddress)) &&
+        hasGuestInfo &&
+        checkoutState.shippingMethod &&
+        checkoutState.shippingMethod.carrier_code &&
+        checkoutState.shippingMethod.method_code &&
+        checkoutState.shippingAdditionalInfo
+      );
+    },
+    isRelevant: () => true,
+    isDisplayable: () => true,
+  },
+  {
+    renderProgressItem: (state, checkoutState, status) => (
+      <ProgressIcon
+        key="payment"
+        status={status}
+        icon="lock"
+        label={messages.payment}
+      />
+    ),
+    renderStep: (props) => (
+      <ChoosePayment
+        initialPayment={{
+          paymentMethod: props.checkoutState.paymentMethod,
+          paymentAdditionalInfo: props.checkoutState.paymentAdditionalInfo,
+          gscAccepted: props.checkoutState.gscAccepted,
+        }}
+        onChoosePayment={(payment) => {
+          props.checkoutTransaction(() => {
+            props.setPaymentMethod(payment.code);
+            props.setPaymentAdditionalInfo(payment.additionalData);
+            props.setGscAcceptance(payment.gsc);
+          });
+        }}
+      />
+    ),
+    isValid: (checkoutState) =>
+      checkoutState.paymentMethod &&
+      checkoutState.paymentAdditionalInfo &&
+      checkoutState.gscAccepted,
+    isRelevant: () => true,
+    isDisplayable: () => true,
+  },
+  {
+    renderProgressItem: (state, checkoutState, status) => (
+      <ProgressIcon
+        key="validation"
+        status={status}
+        icon="checkmark-circle"
+        label={messages.validation}
+      />
+    ),
+    renderStep: (props) => (
+      <PlaceOrder
+        email={props.checkoutState.email}
+        billingAddress={props.checkoutState.billingAddress}
+        paymentMethod={props.checkoutState.paymentMethod}
+        paymentFlowType={checkoutFlowOf(props.checkoutState.paymentMethod)}
+        paymentAdditionalData={props.checkoutState.paymentAdditionalInfo}
+        onOrderPlaced={(orderId, paymentMessage) =>
+          props.markAsPlaced({
+            orderId,
+            paymentMessage,
+          })
+        }
+        location={props.location}
+      />
+    ),
+    isValid: (checkoutState) => checkoutState.isPlaced,
+    isRelevant: () => true,
+    isDisplayable: (checkoutState) => !!checkoutState.paymentMethod,
+  },
+  {
+    renderStep: (props) => (
+      <Redirect
+        to={{
+          pathname: "/checkout/success",
+          state: {
+            ...props.checkoutState.placedOrderData,
+            checkoutState: props.checkoutState,
+          },
+        }}
+      />
+    ),
+    isValid: (checkoutState) => false,
+    isRelevant: () => true,
+    isDisplayable: (checkoutState) => checkoutState.isPlaced,
+  },
+];
+
+export default steps;


### PR DESCRIPTION
This PR adds an "alternative checkout flow" example, which merges the two first steps; Address and Shipping method selection.

Note that it is a "naive" implementation, and although working, it only serves as an example as to how to modify the checkout flow.

The enhancers have been overriden to move the mutation part to the parent `AddressAndShippingMethod` component.