### PR TITLE
feat(client-side-logout-detection): add an initial working example

### DIFF
--- a/client-side-logout-detection/README.md
+++ b/client-side-logout-detection/README.md
@@ -1,0 +1,65 @@
+# Client side logout detection example
+
+This example demonstrates how to detect when a user has logged out of your application during a client-side navigation.
+
+## Why?
+
+It can be helpful if you have strong authentication constraints on your application and short session lifespan.
+
+When users navigate client-side, they can be unexpectedly logged out (without an action from their side). Monitoring this state change allows you to act upon it, for instance to redirect the user on the login page.
+
+## What?
+
+It adds a sample [GraphQL module](https://developers.front-commerce.com/docs/2.x/essentials/extend-the-graphql-schema) containing:
+
+- a lightweight way to know whether the user is logged in or not
+- a fake field to use for simulating an unexpected logout
+
+It also contains some theme files allowing to trigger an unexpected logout and visually displays (in the footer) the state of the monitoring component: `<AutoRedirectOnLogout />`
+
+## Usage
+
+1. add the `examples` module to your project (see [../README.md](../README.md))
+2. register the `examples/client-side-logout-detection` module, GraphQL module and theme in your project:
+
+```diff
+--- a/.front-commerce.js
++++ b/.front-commerce.js
+@@ -2,21 +2,25 @@ module.exports = {
+   name: "Front-Commerce Skeleton",
+   url: "http://localhost:4000",
+   modules: [
+     "./node_modules/front-commerce/theme-chocolatine",
++    "./examples/client-side-logout-detection",
+     "./src",
+   ],
+   serverModules: [
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
+     { name: "Magento2", path: "server/modules/magento2" },
++    {
++      name: "ForceLogout",
++      path: "./examples/client-side-logout-detection/server/forceLogout",
++    },
+   ],
+   webModules: [
+     { name: "FrontCommerce", path: "front-commerce/src/web" },
+     { name: "ThemeChocolatine", path: "front-commerce/theme-chocolatine/web" },
++    {
++      name: "ClientSideLogoutDetectionExample",
++      path: "./examples/client-side-logout-detection/web",
++    },
+     { name: "Skeleton", path: "./src/web" },
+   ],
+ };
+
+```
+
+**Note: if you've customized the `<Home />` and `<GenericLayout />` components, you should update them similarly to what is implemented in this module in order to test the example.**
+
+Restart your application!
+
+## Test
+
+You can simulate an unexpected logout by navigating (client-side or directly) to http://localhost:4000/forceLogout
+
+We recommend to monitor the `<AutoRedirectOnLogout />` output in your theme along with your DevTools Network and Console tabs to understand what's going on.

--- a/client-side-logout-detection/server/forceLogout/index.js
+++ b/client-side-logout-detection/server/forceLogout/index.js
@@ -1,0 +1,39 @@
+import gql from "graphql-tag";
+import { makeAuthServiceFromRequest } from "server/modules/magento2/core/factories";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  namespace: "Examples/ForceLogout",
+  dependencies: ["Magento2/Customer"],
+  typeDefs: gql`
+    extend type Query {
+      isLoggedIn: Boolean
+      simulateUnattendedLogout: String
+    }
+  `,
+  resolvers: {
+    Query: {
+      /**
+       * A lightweight way to check if the user is logged in,
+       * for projects not using the CustomerCache.
+       *
+       * Otherwise, use `me.id` (Customer type)
+       *
+       * @see https://developers.front-commerce.com/docs/2.x/magento2/advanced#caching-current-customers-information
+       */
+      isLoggedIn: (_parent, _args, { req }) => {
+        const authService = makeAuthServiceFromRequest(req);
+        return authService.isAuthenticated();
+      },
+      simulateUnattendedLogout: async (_parent, _args, { loaders }) => {
+        // simulate latency
+        await sleep(Math.random() * 3000);
+        // simulate unattended logout
+        loaders.Customer.logout();
+
+        return "Hello World!";
+      },
+    },
+  },
+};

--- a/client-side-logout-detection/web/theme/components/AutoRedirectOnLogout/AutoRedirectOnLogout.js
+++ b/client-side-logout-detection/web/theme/components/AutoRedirectOnLogout/AutoRedirectOnLogout.js
@@ -1,0 +1,15 @@
+import React from "react";
+import EnhanceAutoRedirectOnLogout from "./EnhanceAutoRedirectOnLogout";
+
+const AutoRedirectOnLogout = (props) => {
+  return (
+    <div style={{ textAlign: "center", fontSize: "0.8em" }}>
+      This component monitors the user login state.
+      <br />
+      {props.isLoggedIn ? "Logged in" : "Logged out"} - Polling:{" "}
+      {props.pollingEnabled ? "enabled" : "disabled"}
+    </div>
+  );
+};
+
+export default EnhanceAutoRedirectOnLogout(AutoRedirectOnLogout);

--- a/client-side-logout-detection/web/theme/components/AutoRedirectOnLogout/EnhanceAutoRedirectOnLogout.js
+++ b/client-side-logout-detection/web/theme/components/AutoRedirectOnLogout/EnhanceAutoRedirectOnLogout.js
@@ -1,0 +1,44 @@
+import { compose, branch } from "recompose";
+import { graphql } from "react-apollo";
+import CheckAuthQuery from "theme/modules/Router/CheckAuthQuery.gql";
+import RedirectOnLogoutQuery from "./RedirectOnLogoutQuery.gql";
+
+// How long after the user has been logged out can we afford to redirect them?
+// Try to avoid too much polling to preserve the server's load!
+const LOGOUT_POLLING_INTERVAL_IN_MS = 500;
+
+const withRedirectOnLogout = (redirectTo) =>
+  compose(
+    graphql(RedirectOnLogoutQuery, {
+      options: {
+        pollInterval: LOGOUT_POLLING_INTERVAL_IN_MS,
+      },
+      props: ({ data }) => {
+        return {
+          pollingEnabled: true,
+          mustRedirect: !data.loading && !data.isLoggedIn,
+        };
+      },
+    }),
+    branch(
+      ({ mustRedirect }) => mustRedirect,
+      () => () => {
+        console.debug("You've been logged out… we're redirecting you."); // eslint-disable-line no-console
+        // Full page reload to prevent any client-side state to kick-in
+        window.location.href = redirectTo;
+        return null;
+      }
+    )
+  );
+
+const EnhanceAutoRedirectOnLogout = compose(
+  // Initial login state, to start polling only when the user is logged in
+  graphql(CheckAuthQuery, {
+    props: ({ data }) => ({
+      isLoggedIn: !data.loading && data.me.id,
+    }),
+  }),
+  branch(({ isLoggedIn }) => isLoggedIn, withRedirectOnLogout("/login"))
+);
+
+export default EnhanceAutoRedirectOnLogout;

--- a/client-side-logout-detection/web/theme/components/AutoRedirectOnLogout/RedirectOnLogoutQuery.gql
+++ b/client-side-logout-detection/web/theme/components/AutoRedirectOnLogout/RedirectOnLogoutQuery.gql
@@ -1,0 +1,10 @@
+query RedirectOnLogoutQuery {
+  # when not using the CustomerCache
+  isLoggedIn
+
+  # alternative if using the CustomerCache
+  # @see https://developers.front-commerce.com/docs/2.x/magento2/advanced#caching-current-customers-information
+  # me {
+  #   id
+  # }
+}

--- a/client-side-logout-detection/web/theme/components/AutoRedirectOnLogout/index.js
+++ b/client-side-logout-detection/web/theme/components/AutoRedirectOnLogout/index.js
@@ -1,0 +1,3 @@
+import AutoRedirectOnLogout from "./AutoRedirectOnLogout";
+
+export default AutoRedirectOnLogout;

--- a/client-side-logout-detection/web/theme/layouts/GenericLayout.js
+++ b/client-side-logout-detection/web/theme/layouts/GenericLayout.js
@@ -1,0 +1,89 @@
+import React, { useRef } from "react";
+import classnames from "classnames";
+import { compose, lifecycle } from "recompose";
+import { Helmet } from "react-helmet-async";
+import { injectIntl, FormattedMessage } from "react-intl";
+import { withCookies } from "react-cookie";
+import { initAnalytics } from "web/core/analytics";
+import config from "config/website";
+import useFullUrl from "web/core/shop/useFullUrl";
+import ErrorBoundary from "theme/components/helpers/ErrorBoundary";
+import PageError from "theme/modules/PageError";
+import Spacer from "theme/components/atoms/Layout/Spacer";
+import withRefreshing from "./withRefreshing";
+import MagicButton from "theme/modules/MagicButton";
+import AutoRedirectOnLogout from "theme/components/AutoRedirectOnLogout";
+
+/**
+ * Component overridden from theme-chocolatine.
+ * It only inserts the <AutoRedirectOnLogout /> component in all pages.
+ */
+
+const GenericLayout = ({
+  header,
+  footer,
+  children,
+  intl,
+  refreshing = false,
+}) => {
+  const url = useFullUrl("/");
+
+  const contentRef = useRef();
+
+  return (
+    <>
+      <button
+        className="sr-only sr-focusable"
+        onClick={() => {
+          contentRef.current && contentRef.current.focus();
+        }}
+      >
+        <FormattedMessage
+          id="layouts.GenericLayout.goToMainContent"
+          defaultMessage="Go to main content"
+        />
+      </button>
+      <div
+        className={classnames("wrapper", { "wrapper--refreshing": refreshing })}
+        itemScope
+        itemType="http://schema.org/WebSite"
+      >
+        {/* this meta is outside Helmet because it describes the itemType="WebSite" */}
+        <meta itemProp="url" content={url} />
+
+        <Helmet defaultTitle={config.defaultTitle}>
+          <html lang={intl.locale} />
+          <meta name="language" content={intl.locale} />
+          <meta name="robots" content="Index,Follow" />
+          <meta name="description" content={config.defaultDescription} />
+          {config.themeColor ? (
+            <meta name="theme-color" content={config.themeColor} />
+          ) : null}
+        </Helmet>
+        {header}
+        <div className="main-content" tabIndex="-1" ref={contentRef}>
+          <ErrorBoundary>
+            {({ hasError }) => (hasError ? <PageError /> : children)}
+          </ErrorBoundary>
+        </div>
+        {footer ? <Spacer /> : null}
+        {footer}
+        <MagicButton />
+
+        {/* This is the only change on this component */}
+        <AutoRedirectOnLogout />
+      </div>
+    </>
+  );
+};
+
+export default compose(
+  injectIntl,
+  withRefreshing(),
+  withCookies,
+  lifecycle({
+    componentDidMount() {
+      initAnalytics(this.props.cookies.get("authorizations"));
+    },
+  })
+)(GenericLayout);

--- a/client-side-logout-detection/web/theme/pages/Home/Home.js
+++ b/client-side-logout-detection/web/theme/pages/Home/Home.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { BodyParagraph } from "theme/components/atoms/Typography/Body";
+import { H2 } from "theme/components/atoms/Typography/Heading";
+import Link from "theme/components/atoms/Typography/Link";
+
+const Home = () => {
+  return (
+    <div className="container">
+      <H2>Test an unexpected logout</H2>
+
+      <BodyParagraph>
+        This page allows you to simulate an unexpected logout. For instance,
+        when the token assigned to your user expires on remote system.
+        <br />
+        Users will be logged out without an explicit intent, which could break
+        their navigation on your website.
+      </BodyParagraph>
+      <BodyParagraph>
+        This example illustrates how you could monitor this event and act on it.
+        <br />
+        Click the link below to simulate a navigation to a new page that will
+        logout the user unexpectedly when fetching data.
+      </BodyParagraph>
+
+      <BodyParagraph>
+        <Link buttonAppearance="default" to="/forceLogout">
+          Simulate logout
+        </Link>
+      </BodyParagraph>
+    </div>
+  );
+};
+
+export default Home;

--- a/client-side-logout-detection/web/theme/routes/forceLogout.js
+++ b/client-side-logout-detection/web/theme/routes/forceLogout.js
@@ -1,0 +1,32 @@
+import React from "react";
+import graphqlWithPreload from "web/core/apollo/graphqlWithPreload";
+import gql from "graphql-tag";
+
+const EnhanceForceLogout = graphqlWithPreload(
+  gql`
+    query ForceLogoutQuery {
+      simulateUnattendedLogout
+    }
+  `,
+  {
+    props: ({ data }) => ({
+      loading: data.loading,
+      theDataWeWantToDisplay: data.simulateUnattendedLogout,
+    }),
+  }
+);
+
+const ForceLogout = (props) => {
+  return (
+    <div className="container">
+      <h1>Force Logout</h1>
+      <p>
+        When fetching data for this page, you were <em>unexpectedly</em> logged
+        out (if logged in)!
+      </p>
+      <p>{props.loading ? "Loading…" : props.theDataWeWantToDisplay}</p>
+    </div>
+  );
+};
+
+export default EnhanceForceLogout(ForceLogout);


### PR DESCRIPTION
to illustrate how to implement polling in an application

See [README.md](https://github.com/front-commerce/examples/blob/illustrate-login-state-monitoring/client-side-logout-detection/README.md) for usage.