### PR TITLE
update initialShipping retrieve props

### DIFF
--- a/alternative-checkout/web/theme/modules/Checkout/AddressAndShippingMethod/AddressAndShippingMethod.js
+++ b/alternative-checkout/web/theme/modules/Checkout/AddressAndShippingMethod/AddressAndShippingMethod.js
@@ -39,10 +39,7 @@ const AddressAndShippingMethod = (props) => {
         billingAddress={props.billingAddress}
         setShippingAddress={props.setShippingAddress}
         setBillingAddress={props.setBillingAddress}
-        initialShipping={{
-          shippingMethod: props.shippingMethod,
-          shippingAdditionalInfo: props.shippingAdditionalInfo,
-        }}
+        initialShipping={props.initialShipping}
         onChooseShippingMethod={props.onChooseShippingMethod}
         onChangeShippingAddress={() => props.gotoStepNumber(0)}
         commandPending={props.commandPending}


### PR DESCRIPTION
In `stepsDefinition` you call `<AddressAndShippingMethod...` component with props 
```
 initialShipping={{
            shippingMethod: props.checkoutState.shippingMethod,
            shippingAdditionalInfo: props.checkoutState.shippingAdditionalInfo,
          }}
```

So to retrieve this props on AddressAndShippingMethod, you need to simply retrieve it with `props.initialShipping`


The issue created: the shipping method selected by the user is not saved if you return to the shipping method select step after choosing one method.